### PR TITLE
Added a few notes on firefox quantum

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -3,4 +3,4 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
-| [Firefox Quantom](https://www.mozilla.org/en-US/firefox/) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
+| [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |

--- a/firefox_quantum_notes.md
+++ b/firefox_quantum_notes.md
@@ -1,0 +1,30 @@
+# Notes on Firefox Quantum
+If you have same experience as presented below, then this is for you:
+![Firefox_quantum](https://i.imgur.com/ZxBIoTx.png)
+
+## Hey, I have Firefox 57.0.4+! How can you still track me?
+Because Firefox Quantum still allows fingerprinting by default, however you can turn it off with a little dwelling in your browser configuration.
+
+### Step 1.
+In browser address bar type `about:config` and press enter, then press "I accept the risk"
+![about:config](https://i.imgur.com/J5VtOsH.png)
+
+### Step 2.
+In configuration page search bar search for `fingerprinting` and look for option `privacy.resistFingerprinting`
+![privacy.resistFingerprinting](https://i.imgur.com/2ZhL0VB.png)
+
+### Step 3.
+Right-click on it and from menu choose `Toggle` option
+
+
+![Toggle](https://i.imgur.com/DUnt2Zd.png)
+
+`privacy.resistFingerprinting` should change it's status from `default` to `modified` and value to `true`
+![Toggled_on](https://i.imgur.com/jQ9TghN.png)
+
+### Final step
+Restart your browser then visit page again. This time firefox should ask you if you want to let page extract data from canvas.
+![Request](https://i.imgur.com/BgCInpu.png)
+
+If you choose to disallow this, then you should be safe.
+![Fingerprinting_resisted](https://i.imgur.com/LSnYsJS.png)


### PR DESCRIPTION
I decided to write a few notes on Firefox Quantum, because it does not resist fingerprinting by default.

## Description
I decided to write a few lines about Firefox Quantum and to add tutorial on how to turn on "Resist fingerprinting" option which is disabled by default

## Related Issue
https://github.com/gautamkrishnar/nothing-private/issues/46

## Motivation and Context
Yeah, so I wrote this to show less advanced users how to resist fingerprinting in Firefox Quantum, hope it helps someone.

## How Has This Been Tested?
I checked it and I think it is complete and looks quite good

## Screenshots (if appropriate):
