### PR TITLE
adding Brave to secure browser list

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -4,3 +4,4 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
+| [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |


### PR DESCRIPTION

## Description
In my testing I found that the browser Brave (https://brave.com/download/) does not allow fingerprinting as long as you use the "Private Tab with Tor" feature.

## Related Issue
https://github.com/gautamkrishnar/nothing-private/issues/38

## Motivation and Context
Adds another browser to the list of those that don't fingerprint users.

## How Has This Been Tested?
1. Installed the Brave Browser
2. Visited https://www.nothingprivate.ml/
3. Entered my name
4. Opened a Private Tab with Tor
5. Navigated to https://www.nothingprivate.ml/
6. Completed the Captcha
7. Verified that the page did not remember my identity in the private tab
