### PR TITLE
Added Tor Browser to list of Secure Browsers

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -6,4 +6,4 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
 | [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
 | [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
-
+| [Waterfox](https://www.waterfoxproject.org/en-US/waterfox/new/?scene=1) | Windows/Linux/Mac | 56.2.5+| [RickyRajinder](https://github.com/rickyrajinder) |

--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -5,5 +5,5 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | ------------- | ------------- | ------------- | ------------- |
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
 | [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
-| [Tor Browser](https://brave.com/) [(Private tab with Tor)](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
+| [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
 

--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -6,4 +6,4 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
 | [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
 | [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
-| [Waterfox](https://www.waterfoxproject.org/en-US/waterfox/new/?scene=1) | Windows/Linux/Mac | 56.2.5+| [RickyRajinder](https://github.com/rickyrajinder) |
+

--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -5,3 +5,5 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | ------------- | ------------- | ------------- | ------------- |
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
 | [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
+| [Tor Browser](https://brave.com/) [(Private tab with Tor)](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Opened nothingprivate.ml on Tor Browser, with tracking protection enabled. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/gautamkrishnar/nothing-private/issues/38

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Identify browsers that do not allow fingerprinting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Open two different tabs of nothingprivate.ml on Tor Browser

## Screenshots (if appropriate):
![torprivate](https://user-images.githubusercontent.com/25396301/48732405-74449780-ebf4-11e8-8fda-77646e7fe738.PNG)
