### PR TITLE
Adding BriskBard to secure browser list

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -6,4 +6,5 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
 | [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
 | [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
+| [BriskBard](https://www.briskbard.com/index.php?lang=en) | Windows| 1.6.9| [jatinsharma28](https://github.com/jatinsharma28)|
 


### PR DESCRIPTION
I found that the  BriskBard browser (https://www.briskbard.com/index.php?lang=en) does not allow fingerprinting . I have submitted a PR to secure browsers list.