### PR TITLE
Update Secure-Browsers.md

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -9,4 +9,4 @@ Following are the browsers that doesn't allows browser fingerpinting. If you are
 | [BriskBard](https://www.briskbard.com/index.php?lang=en) | Windows| 1.6.9| [jatinsharma28](https://github.com/jatinsharma28)|
 | [Waterfox](https://www.waterfox.net/) [(See notes)](waterfox_notes.md) | Windows/Linux/Mac | 56.2.11+ | [jragard](https://github.com/jragard) |
 | [Pale Moon](https://www.palemoon.org/) [(See notes)](pale_moon_notes.md) | Windows/Linux | 28.5.2+ | [jragard](https://github.com/jragard) |
-
+| [Firefox](https://www.mozilla.org/en-US/firefox/download/) [(See notes)](https://github.com/awaisrafiq410/hacktoberfest2019/blob/master/awais.md) | Windows/Linux | 69.0.1 (64-bit) | [awaisrafiq410](https://github.com/awaisrafiq410) |


### PR DESCRIPTION
Added Firefox 69.0.1 as a secure browser

I'm testing Firefox because it resists fingerprinting by default. 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is nothing to do. All you have to do is download firefox 69.0.0 or above.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is easy for every user.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I checked it and I think it is complete and looks quite good
## Screenshots (if appropriate):
![start_page](https://i.imgur.com/tEElcqf.png)
![see_megic](https://i.imgur.com/6MpE912.png)
![final_test](https://i.imgur.com/tEElcqf.png)