### PR TITLE
create a database truncation script for cronjob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 cypress/videos/
 cypress/screenshots/
 docker/data
+db_server/visitors.txt

--- a/db_server/README.md
+++ b/db_server/README.md
@@ -1,5 +1,6 @@
 # Nothing private Server files
 
+* [cron.db](cron.php) truncates the database and updates the visitors.txt file
 * [safedb.php](safedb.php) contains the backend code written in PHP to process the database.
 * [db.sql](db.sql) contains database schema definition.
 * [forgetme.php](forgetme.php) is used to delete the user's fingerprint data from the database.

--- a/db_server/cron.php
+++ b/db_server/cron.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/connection.php';
+
+$stmt = $mysqli->prepare('SELECT count(*) cnt FROM browsertab');
+$stmt->execute();
+$stmt->bind_result($count_from_db);
+$stmt->fetch();
+$stmt->free_result();
+
+$visitors_file_name = __DIR__ . '/visitors.txt';
+$count_from_file = (int)@file_get_contents($visitors_file_name);
+file_put_contents($visitors_file_name, $count_from_db + $count_from_file);
+
+$stmt = $mysqli->prepare('TRUNCATE TABLE browsertab');
+$stmt->execute();


### PR DESCRIPTION
Created a php script that can be executed via cron job and does the following:
* It truncates the existing entries in the nothing private database.
* It increments the number saved in visitors.txt by the number of deleted rows

**Related Issue:** Create a PHP script that truncates the Nothing Private database via cronjob #72

