### PR TITLE
Removed Brave from Secure-Browsers.md

### DIFF
--- a/Secure-Browsers.md
+++ b/Secure-Browsers.md
@@ -4,7 +4,6 @@ The following list shows browsers that don't allow browser fingerpinting. If you
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
 | [Firefox Quantum](https://www.mozilla.org/en-US/firefox/) [(See notes)](firefox_quantum_notes.md) | Windows/Linux/Mac | 57.0.4+ | [CrisMen](https://github.com/CrisMen) |
-| [Brave](https://brave.com/) [(Private tab with Tor)](https://brave.com/tor-tabs-beta) | Windows/Linux/Mac | 0.24.0+| [ZCapshaw](https://github.com/zcapshaw) |
 | [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
 | [BriskBard](https://www.briskbard.com/index.php?lang=en) | Windows| 1.6.9| [jatinsharma28](https://github.com/jatinsharma28)|
 | [Waterfox](https://www.waterfox.net/) [(See notes)](waterfox_notes.md) | Windows/Linux/Mac | 56.2.11+ | [jragard](https://github.com/jragard) |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Unfortunately Brave failed the test for me.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/gautamkrishnar/nothing-private/issues/38

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Brave | 0.70.121 Chromium: 78.0.3904.70 (Official Build) (64-bit)
-- | --
Revision | edb9c9f3de0247fd912a77b7f6cae7447f6d3ad5-refs/branch-heads/3904@{#800}
OS | Windows 10 OS Version 1903 (Build 18362.418)

1. Installed the Brave Browser
1. Visited https://www.nothingprivate.ml/
1. Entered my name
1. Opened a Private Tab with Tor
1. Navigated to https://www.nothingprivate.ml/
1. Completed the Captcha
1. Verified that the page remembered my identity in the private tab with tor

Addendum: No matter how you make your first visit, when you type your name: using either of regular tab, private tab, or private tab with tor. In each case NP still identifies you.

## Screenshots (if appropriate):
