### PR TITLE
add firefox to the list of secure browsers

### DIFF
--- a/secure-browsers/README.md
+++ b/secure-browsers/README.md
@@ -8,3 +8,4 @@ The following list shows browsers that don't allow browser fingerpinting. If you
 | [Pale Moon](https://www.palemoon.org/) [(See notes)](pale_moon_notes.md) | Windows/Linux | 28.5.2+ | [jragard](https://github.com/jragard) |
 | [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium) [(See notes)](ungoogled_chromium_notes.md) | Windows/Linux/Mac | 80.0.3987.149-2+ | [Nunbit](https://github.com/nunbit) |
 | [Bromite](https://www.bromite.org/) | Android | v77+ | [Nunbit](https://github.com/nunbit) |
+| [Firefox](https://www.mozilla.org/en-US/firefox/new/) see [notes](firefox.md) | Windows/Linux/Mac | v57+ | [cherti](https://github.com/cherti) |

--- a/secure-browsers/firefox.md
+++ b/secure-browsers/firefox.md
@@ -1,3 +1,5 @@
 # Notes on Firefox
 
 To enable Firefox' internal fingerprinting countermeasures, enter `about:config` into your address bar, confirm the security check and search for `privacy.resistFingerprinting`. Set this option to true.
+
+(Keep in mind that fingerprinting protections can break certain websites which rely on the features the fingerprinting protection takes away, so this might be a knob to turn if you encounter problems with e.g. using media devices like microphones on certain websites.)

--- a/secure-browsers/firefox.md
+++ b/secure-browsers/firefox.md
@@ -1,0 +1,3 @@
+# Notes on Firefox
+
+To enable Firefox' internal fingerprinting countermeasures, enter `about:config` into your address bar, confirm the security check and search for `privacy.resistFingerprinting`. Set this option to true.


### PR DESCRIPTION
This PR adds Firefox to the list of secure browsers by only using internal configuration options.