### PR TITLE
remove torbrowser from the list of secure browsers

### DIFF
--- a/secure-browsers/README.md
+++ b/secure-browsers/README.md
@@ -3,7 +3,6 @@ The following list shows browsers that don't allow browser fingerpinting. If you
 
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
-| [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
 | [BriskBard](https://www.briskbard.com/index.php?lang=en) | Windows| 1.6.9| [jatinsharma28](https://github.com/jatinsharma28)|
 | [Pale Moon](https://www.palemoon.org/) [(See notes)](pale_moon_notes.md) | Windows/Linux | 28.5.2+ | [jragard](https://github.com/jragard) |
 | [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium) [(See notes)](ungoogled_chromium_notes.md) | Windows/Linux/Mac | 80.0.3987.149-2+ | [Nunbit](https://github.com/nunbit) |


### PR DESCRIPTION
According to the discussion in https://github.com/gautamkrishnar/nothing-private/pull/107 (as well as https://github.com/gautamkrishnar/nothing-private/pull/106) the Tor Browser does not comply with the requirements for the list of "secure browsers" as outlined, hence this PR removes it.