### PR TITLE
Correct Version numbers of Firefox and Torbrowser to be historically …

### DIFF
--- a/browsers-with-countermeasures/README.md
+++ b/browsers-with-countermeasures/README.md
@@ -14,6 +14,7 @@ Browsers that implement this approach include
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
 | [Firefox](https://www.mozilla.org/en-US/firefox/new/) | Windows/Linux/Mac/Android | v78+ | [cherti](https://github.com/cherti) |
+| [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 10.0+ | [RickyRajinder](https://github.com/rickyrajinder) |
 | [BriskBard](https://www.briskbard.com/index.php?lang=en) | Windows| 1.6.9| [jatinsharma28](https://github.com/jatinsharma28)|
 | [Pale Moon](https://www.palemoon.org/) [(See notes)](pale_moon_notes.md) | Windows/Linux | 28.5.2+ | [jragard](https://github.com/jragard) |
 | [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium) [(See notes)](ungoogled_chromium_notes.md) | Windows/Linux/Mac | 80.0.3987.149-2+ | [Nunbit](https://github.com/nunbit) |
@@ -32,5 +33,5 @@ Browsers that implement this approach include
 
 | Browser | Platform | Version | Reported By |
 | ------------- | ------------- | ------------- | ------------- |
-| [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0.3+| [RickyRajinder](https://github.com/rickyrajinder) |
-| [Firefox](https://www.mozilla.org/en-US/firefox/new/) | Windows/Linux/Mac/Android | v68+ - 77 | [cherti](https://github.com/cherti) |
+| [Tor Browser](https://www.torproject.org/download/download) | Windows/Linux/Mac | 8.0 - 9.5 | [RickyRajinder](https://github.com/rickyrajinder) |
+| [Firefox](https://www.mozilla.org/en-US/firefox/new/) | Windows/Linux/Mac/Android | v58 - 77 | [cherti](https://github.com/cherti) |


### PR DESCRIPTION
…correct (thanks @Thorin-Oakenpants)

as discussed in https://github.com/gautamkrishnar/nothing-private/pull/107

I have added the likely correct version numbers for Torbrowser in as well, albeit being inaccurate with regards to the alpha I think it is a fair assumption that the table is referring to released versions. In a month from now latest, no one will decide to pick a `10.0.a1` for usage anyways, so I'd say just don't bother and finish things up here.